### PR TITLE
Azure rm py3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Tested
 
 We maintain a list of validated plugins tested so far:
 
+* Azure
 * AWS/EC2
 * Digital Ocean
 * Docker

--- a/inventory/azure_rm.py
+++ b/inventory/azure_rm.py
@@ -202,13 +202,10 @@ import sys
 import inspect
 
 from os.path import expanduser
-#from jeti.module_utils.six.moves import configparser as cp
 import configparser
 from configparser import ConfigParser
-#from six.moves.urllib.parse as urlparse
 import urllib
 from urllib import parse as urlparse
-#import jeti.module_utils.six.moves.urllib.parse as urlparse
 
 HAS_AZURE = True
 HAS_AZURE_EXC = None

--- a/inventory/azure_rm.py
+++ b/inventory/azure_rm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2016 Matt Davis, <mdavis@ansible.com>
 #                    Chris Houseknecht, <house@redhat.com>
@@ -202,8 +202,13 @@ import sys
 import inspect
 
 from os.path import expanduser
-from jeti.module_utils.six.moves import configparser as cp
-import jeti.module_utils.six.moves.urllib.parse as urlparse
+#from jeti.module_utils.six.moves import configparser as cp
+import configparser
+from configparser import ConfigParser
+#from six.moves.urllib.parse as urlparse
+import urllib
+from urllib import parse as urlparse
+#import jeti.module_utils.six.moves.urllib.parse as urlparse
 
 HAS_AZURE = True
 HAS_AZURE_EXC = None
@@ -382,7 +387,7 @@ class AzureRM(object):
         path = expanduser("~")
         path += "/.azure/credentials"
         try:
-            config = cp.ConfigParser()
+            config = configparser.ConfigParser()
             config.read(path)
         except Exception as exc:
             self.fail("Failed to access {0}. Check that the file exists and you have read "
@@ -913,7 +918,7 @@ class AzureInventory(object):
         config = None
         settings = None
         try:
-            config = cp.ConfigParser()
+            config = configparser.ConfigParser()
             config.read(path)
         except Exception:
             pass


### PR DESCRIPTION
This gets the azure script functioning.
Its python3 only now and doesn't use module_utils now

I'm going to leave my setup notes here for future reference and in case anyone else is coming to this cold without anything previously setup.

Install the azure CLI (possibly not essential)

https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt

Install the azure python libs

`pip3 install 'azure=4.0.0' --upgrade`

(note the azure meta-package is deprecated after 4.x so there is almost certainly a leaner way to set this up but it wasn't primary concern, so I just installed older package).

If you are setting up from scratch once you have an azure account I found I needed to go through the steps to setup a service principal documented here: https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal

Don't forget to add your subscription, tenant, client id and secret settings to 

~/.azure/credentials

which is ini file format and needs a header.  So fill in these values.
Confusingly sometimes tenant is referred to as directory in the azure portal.
```
[default]
subscription_id=
client_id=
secret=
tenant=
```
and chmod your credential files to something like 600 to keep the details private.

`chmod 600 ~/.azure/credentials`

I noticed that changing 

`include_powerstate=yes`
to
`include_powerstate=no`

did marginally increase the speed but it is quite slow 4-5 seconds in either case.




