### PR TITLE
Say Hello (python3), Wave Goodbye (module utils six wrapper)

### DIFF
--- a/inventory/abiquo.py
+++ b/inventory/abiquo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 '''
@@ -210,7 +210,7 @@ if __name__ == '__main__':
     enterprise = {}
 
     # Read config
-    config = ConfigParser.SafeConfigParser()
+    config = ConfigParser.ConfigParser()
     for configfilename in [os.path.abspath(sys.argv[0]).rstrip('.py') + '.ini', 'abiquo.ini']:
         if os.path.exists(configfilename):
             config.read(configfilename)

--- a/inventory/apache-libcloud.py
+++ b/inventory/apache-libcloud.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Sebastien Goasguen <runseb@gmail.com>
 #
@@ -26,7 +26,16 @@ Apache Libcloud generic external inventory script
 Generates inventory that Jeti can understand by making API request to
 Cloud providers using the Apache libcloud library.
 
-This script also assumes there is a libcloud.ini file alongside it
+Setup
+=====
+
+Install libcloud as follows:
+
+pip3 install apache-libcloud
+
+This script also assumes there is a 'libcloud.ini' file alongside it.
+(Note the name, you might be expecting apache-libcloud.ini)
+Configure the libcloud.ini according to your needs.
 
 '''
 
@@ -35,8 +44,8 @@ import os
 import argparse
 import re
 from time import time
-
-from jeti.module_utils.six import iteritems, string_types
+import six
+from six import iteritems, string_types
 import configparser as ConfigParser
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
@@ -94,7 +103,7 @@ class LibcloudInventory(object):
     def read_settings(self):
         ''' Reads the settings from the libcloud.ini file '''
 
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.ConfigParser()
         libcloud_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'libcloud.ini')
         libcloud_ini_path = os.environ.get('LIBCLOUD_INI_PATH', libcloud_default_ini_path)
         config.read(libcloud_ini_path)

--- a/inventory/cloudforms.py
+++ b/inventory/cloudforms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: set fileencoding=utf-8 :
 #
 # Copyright (C) 2016 Guido Günther <agx@sigxcpu.org>
@@ -101,7 +101,7 @@ class CloudFormsInventory(object):
         """
         Reads the settings from the cloudforms.ini file
         """
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.ConfigParser()
         config_paths = [
             os.path.dirname(os.path.realpath(__file__)) + '/cloudforms.ini',
             "/etc/jeti/cloudforms.ini",

--- a/inventory/cloudstack.py
+++ b/inventory/cloudstack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>

--- a/inventory/cobbler.py
+++ b/inventory/cobbler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Cobbler external inventory script
@@ -20,6 +20,9 @@ that those correspond to addresses.
 Tested with Cobbler 2.0.11.
 
 Changelog:
+    - 2023-09-10 jhawkesworth: mechanical conversion to python3 to allow removal of module utils.
+         Untested, but script is now self-contained..
+
     - 2015-06-21 dmccue: Modified to support run-once _meta retrieval, results in
          higher performance at ansible startup.  Groups are determined by owner rather than
          default mgmt_classes.  DNS name determined from hostname. cobbler values are written
@@ -54,11 +57,13 @@ import argparse
 import os
 import re
 from time import time
-import xmlrpclib
-
+#from xmlrpc.server import SimpleXMLRpcServer as Server
+#import xmlrpc.server
+import xmlrpc.client as xc
 import json
 
-from jeti.module_utils.six import iteritems
+import six
+from six import iteritems
 import configparser as ConfigParser
 
 # NOTE -- this file assumes Jeti is being accessed FROM the cobbler
@@ -108,7 +113,7 @@ class CobblerInventory(object):
 
     def _connect(self):
         if not self.conn:
-            self.conn = xmlrpclib.Server(self.cobbler_host, allow_none=True)
+            self.conn = xc.Server(self.cobbler_host, allow_none=True)
             self.token = None
             if self.cobbler_username is not None:
                 self.token = self.conn.login(self.cobbler_username, self.cobbler_password)
@@ -131,7 +136,7 @@ class CobblerInventory(object):
         if(self.ignore_settings):
             return
 
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.ConfigParser()
         config.read(os.path.dirname(os.path.realpath(__file__)) + '/cobbler.ini')
 
         self.cobbler_host = config.get('cobbler', 'host')
@@ -207,7 +212,7 @@ class CobblerInventory(object):
                 for (iname, ivalue) in iteritems(interfaces):
                     if ivalue['management'] or not ivalue['static']:
                         this_dns_name = ivalue.get('dns_name', None)
-                        if this_dns_name is not None and this_dns_name is not "":
+                        if this_dns_name != None and this_dns_name != "":
                             dns_name = this_dns_name
 
             if dns_name == '' or dns_name is None:

--- a/inventory/consul_io.py
+++ b/inventory/consul_io.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
@@ -197,7 +197,8 @@ except ImportError as e:
     sys.exit("""failed=True msg='python-consul required for this module.
 See https://python-consul.readthedocs.io/en/latest/#installation'""")
 
-from jeti.module_utils.six import iteritems
+import six
+from six import iteritems
 
 
 class ConsulInventory(object):
@@ -461,7 +462,7 @@ class ConsulConfig(dict):
 
     def read_settings(self):
         ''' Reads the settings from the consul_io.ini file (or consul.ini for backwards compatibility)'''
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         if os.path.isfile(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini'):
             config.read(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini')
         else:
@@ -517,7 +518,7 @@ class ConsulConfig(dict):
         scheme = 'http'
 
         if hasattr(self, 'url'):
-            from jeti.module_utils.six.moves.urllib.parse import urlparse
+            from six.moves.urllib.parse import urlparse
             o = urlparse(self.url)
             if o.hostname:
                 host = o.hostname

--- a/inventory/digital_ocean.py
+++ b/inventory/digital_ocean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 DigitalOcean external inventory script

--- a/inventory/docker.py
+++ b/inventory/docker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # (c) 2016 Paul Durivage <paul.durivage@gmail.com>
 #          Chris Houseknecht <house@redhat.com>

--- a/inventory/fleet.py
+++ b/inventory/fleet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 fleetctl base external inventory script. Automatically finds the IPs of the booted coreos instances and
 returns it under the host group 'coreos'

--- a/inventory/foreman.py
+++ b/inventory/foreman.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: set fileencoding=utf-8 :
 #
 # Copyright (C) 2016 Guido Günther <agx@sigxcpu.org>,
@@ -74,7 +74,7 @@ class ForemanInventory(object):
     def read_settings(self):
         """Reads the settings from the foreman.ini file"""
 
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.ConfigParser()
         config.read(self.config_paths)
 
         # Foreman API related

--- a/inventory/freeipa.py
+++ b/inventory/freeipa.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -8,7 +8,8 @@ import json
 import os
 import sys
 from ipalib import api, errors, __version__ as IPA_VERSION
-from jeti.module_utils.six import u
+import six
+from six import u
 
 
 def initialize():

--- a/inventory/gce.py
+++ b/inventory/gce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright: (c) 2013, Google Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/inventory/jail.py
+++ b/inventory/jail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Michael Scherer <misc@zarb.org>
 #

--- a/inventory/landscape.py
+++ b/inventory/landscape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2015, Marc Abramowitz <marca@surveymonkey.com>
 #

--- a/inventory/libvirt_lxc.py
+++ b/inventory/libvirt_lxc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Michael Scherer <misc@zarb.org>
 #

--- a/inventory/linode.py
+++ b/inventory/linode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Linode external inventory script

--- a/inventory/lxc_inventory.py
+++ b/inventory/lxc_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # (c) 2015-16 Florian Haas, hastexo Professional Services GmbH
 # <florian@hastexo.com>

--- a/inventory/lxd.py
+++ b/inventory/lxd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Michael Scherer <misc@zarb.org>
 # (c) 2014, Hiroaki Nakamura <hnakamur@gmail.com>
@@ -37,7 +37,7 @@ hosts = {}
 result = {}
 
 # Read the settings from the lxd.ini file
-config = configparser.SafeConfigParser()
+config = configparser.ConfigParser()
 config.read(os.path.dirname(os.path.realpath(__file__)) + '/lxd.ini')
 if config.has_option('lxd', 'resource'):
     resource = config.get('lxd', 'resource')

--- a/inventory/nagios_livestatus.py
+++ b/inventory/nagios_livestatus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2015, Yannig Perre <yannig.perre@gmail.com>
 #
@@ -36,18 +36,19 @@ import re
 import argparse
 import sys
 
-import configparserimport json
+import configparser
+import json
 
 try:
     from mk_livestatus import Socket
 except ImportError:
-    sys.exit("Error: mk_livestatus is needed. Try something like: pip install python-mk-livestatus")
+    sys.exit("Error: mk_livestatus is needed. Try something like: pip3 install python-mk-livestatus")
 
 
 class NagiosLivestatusInventory(object):
 
     def parse_ini_file(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.read(os.path.dirname(os.path.realpath(__file__)) + '/nagios_livestatus.ini')
         for section in config.sections():
             if not config.has_option(section, 'livestatus_uri'):

--- a/inventory/nagios_ndo.py
+++ b/inventory/nagios_ndo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2014, Jonathan Lestrelin <jonathan.lestrelin@gmail.com>
 #
@@ -29,7 +29,8 @@ Configuration is read from `nagios_ndo.ini`.
 import os
 import argparse
 import sys
-import configparserimport json
+import configparser
+import json
 
 try:
     from sqlalchemy import text
@@ -41,7 +42,7 @@ except ImportError:
 class NagiosNDOInventory(object):
 
     def read_settings(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.read(os.path.dirname(os.path.realpath(__file__)) + '/nagios_ndo.ini')
         if config.has_option('ndo', 'database_uri'):
             self.ndo_database_uri = config.get('ndo', 'database_uri')

--- a/inventory/nsot.py
+++ b/inventory/nsot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 nsot
@@ -148,7 +148,8 @@ from pynsot.client import get_api_client
 from pynsot.app import HttpServerError
 from click.exceptions import UsageError
 
-from jeti.module_utils.six import string_types
+import six
+from six import string_types
 
 
 def warning(*objs):

--- a/inventory/openshift.py
+++ b/inventory/openshift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Michael Scherer <misc@zarb.org>
 #
@@ -46,7 +46,7 @@ def get_from_rhc_config(variable):
     if os.path.exists(CONF_FILE):
         if not configparser:
             ini_str = '[root]\n' + open(CONF_FILE, 'r').read()
-            configparser = ConfigParser.SafeConfigParser()
+            configparser = ConfigParser.ConfigParser()
             configparser.readfp(StringIO.StringIO(ini_str))
         try:
             return configparser.get('root', variable)

--- a/inventory/openstack_inventory.py
+++ b/inventory/openstack_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2012, Marco Vito Moscaritolo <marco@agavee.com>
 # Copyright (c) 2013, Jesse Keating <jesse.keating@rackspace.com>

--- a/inventory/openvz.py
+++ b/inventory/openvz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # openvz.py

--- a/inventory/ovirt.py
+++ b/inventory/ovirt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015 IIX Inc.
 #
 # This file is part of jeti
@@ -123,7 +123,7 @@ class OVirtInventory(object):
         # This provides empty defaults to each key, so that environment
         # variable configuration (as opposed to INI configuration) is able
         # to work.
-        config = ConfigParser.SafeConfigParser(defaults={
+        config = ConfigParser.ConfigParser(defaults={
             'ovirt_url': '',
             'ovirt_username': '',
             'ovirt_password': '',

--- a/inventory/ovirt4.py
+++ b/inventory/ovirt4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016 Red Hat, Inc.
@@ -115,7 +115,7 @@ def create_connection():
     config_path = os.environ.get('OVIRT_INI_PATH', default_path)
 
     # Create parser and add ovirt section if it doesn't exist:
-    config = configparser.SafeConfigParser(
+    config = configparser.ConfigParser(
         defaults={
             'ovirt_url': os.environ.get('OVIRT_URL'),
             'ovirt_username': os.environ.get('OVIRT_USERNAME'),

--- a/inventory/proxmox.py
+++ b/inventory/proxmox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2014  Mathieu GAUTHIER-LAFAYE <gauthierl@lapth.cnrs.fr>
 #
@@ -24,14 +24,19 @@
 # used to specify group membership:
 #
 # { "groups": ["utility", "databases"], "a": false, "b": true }
+#
+# Updated 2023 by Jon Hawkesworth (jhawkesworth)
+#
+# Run under python3 only
 
 import json
 import os
 import sys
 from optparse import OptionParser
 
-from jeti.module_utils.six import iteritems
-from jeti.module_utils.six.moves.urllib.parse import urlencode
+import six
+from six import iteritems
+from six.moves.urllib.parse import urlencode
 
 from jeti.module_utils.urls import open_url
 

--- a/inventory/rackhd.py
+++ b/inventory/rackhd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of jeti
 #

--- a/inventory/rax.py
+++ b/inventory/rax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Jesse Keating <jesse.keating@rackspace.com,
 #           Paul Durivage <paul.durivage@rackspace.com>,
@@ -152,7 +152,8 @@ import argparse
 import warnings
 import collections
 
-from jeti.module_utils.six import iteritems
+import six
+from six import iteritems
 import configparser as ConfigParser
 
 import json
@@ -167,7 +168,7 @@ from time import time
 
 from jeti.constants import get_config
 from jeti.module_utils.parsing.convert_bool import boolean
-from jeti.module_utils.six import text_type
+from six import text_type
 
 NON_CALLABLES = (text_type, str, bool, dict, int, list, type(None))
 

--- a/inventory/rudder.py
+++ b/inventory/rudder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015, Normation SAS
 #
@@ -55,8 +55,9 @@ import re
 import argparse
 import httplib2 as http
 from time import time
-from jeti.module_utils import six
-import configparserfrom jeti.module_utils.six.moves.urllib.parse import urlparse
+import six
+import configparser
+from six.moves.urllib.parse import urlparse
 
 import json
 

--- a/inventory/scaleway.py
+++ b/inventory/scaleway.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 '''
@@ -41,8 +41,8 @@ all: Contains all hosts defined in Scaleway.
 import copy
 import os
 import requests
-from jeti.module_utils import six
-import configparserimport sys
+import configparser
+import sys
 import time
 import traceback
 
@@ -84,8 +84,6 @@ class ScalewayAPI:
         else:
             raise ValueError(
                 "Resource %s not found in Scaleway API response" % (resource))
-
-
 def env_or_param(env_key, param=None, fallback=None):
     env_value = os.environ.get(env_key)
 
@@ -210,10 +208,7 @@ if __name__ == '__main__':
     inventory = {}
 
     # Read config
-    if six.PY3:
-        config = configparser.ConfigParser()
-    else:
-        config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     for configfilename in [os.path.abspath(sys.argv[0]).rsplit('.py')[0] + '.ini', 'scaleway.ini']:
         if os.path.exists(configfilename):
             config.read(configfilename)

--- a/inventory/serf.py
+++ b/inventory/serf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2015, Marc Abramowitz <marca@surveymonkey.com>
 #

--- a/inventory/softlayer.py
+++ b/inventory/softlayer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 SoftLayer external inventory script.
 

--- a/inventory/spacewalk.py
+++ b/inventory/spacewalk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Spacewalk external inventory script
@@ -35,8 +35,8 @@ import time
 from optparse import OptionParser
 import subprocess
 import json
-
-from jeti.module_utils.six import iteritems
+# six is here for iteritems
+import six
 import configparser as ConfigParser
 
 

--- a/inventory/ssh_config.py
+++ b/inventory/ssh_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2014, Tomas Karasek <tomas.karasek@digile.fi>
 #
@@ -48,7 +48,7 @@ import json
 
 import paramiko
 
-from jeti.module_utils.common._collections_compat import MutableSequence
+from collections.abc import MutableSequence
 
 SSH_CONF = '~/.ssh/config'
 

--- a/inventory/vagrant.py
+++ b/inventory/vagrant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Vagrant external inventory script. Automatically finds the IP of the booted vagrant vm(s), and
 returns it under the host group 'vagrant'
@@ -42,8 +42,9 @@ from optparse import OptionParser
 from collections import defaultdict
 import json
 
-from jeti.module_utils._text import to_text
-from jeti.module_utils.six.moves import StringIO
+import six
+#from jeti.module_utils._text import to_text
+from six.moves import StringIO
 
 
 _group = 'vagrant'  # a default group
@@ -75,7 +76,8 @@ def get_ssh_config():
 # list all the running boxes
 def list_running_boxes():
 
-    output = to_text(subprocess.check_output(["vagrant", "status"]), errors='surrogate_or_strict').split('\n')
+    #output = to_text(subprocess.check_output(["vagrant", "status"]), errors='surrogate_or_strict').split('\n')
+    output = subprocess.check_output(["vagrant", "status"]).split('\n')
 
     boxes = []
 

--- a/inventory/vbox.py
+++ b/inventory/vbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of jeti,
 #

--- a/inventory/vmware.py
+++ b/inventory/vmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''
 VMware Inventory Script
@@ -38,8 +38,9 @@ import ssl
 import sys
 import time
 
-from jeti.module_utils.common._collections_compat import MutableMapping
-from jeti.module_utils.six import integer_types, text_type, string_types
+from collections.abc import MutableMapping
+import six
+from six import integer_types, text_type, string_types
 import configparser
 # Disable logging message trigged by pSphere/suds.
 try:
@@ -63,7 +64,7 @@ from suds.sudsobject import Object as SudsObject
 class VMwareInventory(object):
 
     def __init__(self, guests_only=None):
-        self.config = configparser.SafeConfigParser()
+        self.config = configparser.ConfigParser()
         if os.environ.get('VMWARE_INI', ''):
             config_files = [os.environ['VMWARE_INI']]
         else:

--- a/inventory/vmware_inventory.py
+++ b/inventory/vmware_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C): 2017, Ansible Project
@@ -40,7 +40,7 @@ from time import time
 
 from jinja2 import Environment
 
-from jeti.module_utils.six import integer_types, PY3
+from six import integer_types
 import configparser
 try:
     import argparse
@@ -234,10 +234,7 @@ class VMWareInventory(object):
             'groupby_custom_field': False}
         }
 
-        if PY3:
-            config = configparser.ConfigParser()
-        else:
-            config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
 
         # where is the config?
         vmware_ini_path = os.environ.get('VMWARE_INI_PATH', defaults['vmware']['ini_path'])

--- a/inventory/zabbix.py
+++ b/inventory/zabbix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2013, Greg Buehler
 # (c) 2018, Filippo Ferrazini
@@ -52,7 +52,7 @@ import json
 class ZabbixInventory(object):
 
     def read_settings(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         conf_path = './zabbix.ini'
         if not os.path.exists(conf_path):
             conf_path = os.path.dirname(os.path.realpath(__file__)) + '/zabbix.ini'

--- a/inventory/zone.py
+++ b/inventory/zone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # (c) 2015, Dagobert Michelsen <dam@baltic-online.de>
 #


### PR DESCRIPTION
This PR says hello to python3 for all the inventory scripts,
and it waves goodbe to any references to module_utils
for things that are present in six.

The following modules still have references to module_utils
but for methods which aren't available in six

abiquo.py
ec2.py
ec2.py
foreman.py
openshift.py
proxmox.py
rax.py
vagrant.py

and such they all fail to complete imports.
I may tackle these at a later date but others are welcome to tackle of course.

While sprucing up these scripts for Jet, it seems sensible to say goodbye to python2 across the board.

Testing


I can't test most of these changes as it would take a ton of time
and money to set up cloud accounts.  I will however leave notes 
here on what I have found.

apache-libcloud.py
Fails after imports
Default configuration is for CloudStack which I can't test.


Tried to test with AZURE_ARM provider but it is going to need a bit more work as it seems the current version of the library supports more ways to initialize the provider drivers than the script currently supports.
Given the sheer number of cloud providers this script supports, it seems well 
worth further attention.


cobbler.py

Crashes with socket.gaierror: [Errno -3] Temporary failure in name resolution
which seems reasonable as I don't have a cobbler server.

consul_io.py

Crashes with 
requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8500): Max retries exceeded with url: /v1/catalog/datacenters (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f4dc27709d0>: Failed to establish a new connection: [Errno 111] Connection refused'))
which is reasonable as I don't have consul set up.

freeipa.py

I couldn't install ipalib, seems to need kerberos setup.
as such it fails before completing imports
Also the following warning likely needs addressing:
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import LooseVersion

nsot.py

runs but does not produce any json output instead the message 'No action requested'.  Looks like if you run with -l it walks you through one-time setup.

proxmox.py
fails during imports (still using module_utils)

rax.py

fails with 
AttributeError: module 'collections' has no attribute 'Mapping'

rudder.py

fails after imports with
Error connecting to Rudder server

spacewalk.py

Fails after imports with
Error: /usr/bin/spacewalk-report is required for operation.

ssh_config.py
produces json (empty but so is my ssh_config)


vagrant.py

fails after imports as vagrant not found.
Had to remove a call to .to_text() to avoid a module_utils import so may need further work. 

vmware.py

fails after imports with
AttributeError: 'NoneType' object has no attribute 'name'

vmware_inventory.py

fails after imports with

Unable to connect to ESXi server due to [Errno -3] Temporary failure in name resolution

also this needs attention:
DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
  
  
All the others I have simply made env look for python3 and changed any references to SafeConfigParser to ConfigParser.

