### PR TITLE
switch to using requests instead of open_url from module utils

### DIFF
--- a/inventory/abiquo.py
+++ b/inventory/abiquo.py
@@ -48,8 +48,8 @@ import time
 import json
 
 import configparser as ConfigParser
-from jeti.module_utils.urls import open_url
-
+import requests
+from requests.auth import HTTPBasicAuth
 
 def api_get(link, config):
     try:
@@ -59,9 +59,9 @@ def api_get(link, config):
         else:
             url = link['href'] + '?limit=0'
             headers = {"Accept": link['type']}
-        result = open_url(url, headers=headers, url_username=config.get('auth', 'apiuser').replace('\n', ''),
-                          url_password=config.get('auth', 'apipass').replace('\n', ''))
-        return json.loads(result.read())
+        auth = HTTPBasicAuth(config.get('auth', 'apiuser').replace('\n', ''), config.get('auth', 'apipass').replace('\n', ''))
+        result = requests.get(url, headers=headers, auth=auth)
+        return result.json
     except Exception:
         return None
 

--- a/inventory/openshift.py
+++ b/inventory/openshift.py
@@ -32,9 +32,10 @@ import json
 import os
 import os.path
 import sys
-import StringIO
+from io import StringIO
+import requests
+from requests.auth import HTTPBasicAuth
 
-from jeti.module_utils.urls import open_url
 import configparser as ConfigParser
 
 configparser = None
@@ -65,8 +66,9 @@ def get_config(env_var, config_var):
 
 def get_json_from_api(url, username, password):
     headers = {'Accept': 'application/json; version=1.5'}
-    response = open_url(url, headers=headers, url_username=username, url_password=password)
-    return json.loads(response.read())['data']
+    auth = HTTPBasicAuth(username, password)
+    response = requests.get(url, headers=headers, auth=auth)
+    return response.json['data']
 
 
 username = get_config('JETI_OPENSHIFT_USERNAME', 'default_rhlogin')

--- a/inventory/proxmox.py
+++ b/inventory/proxmox.py
@@ -38,8 +38,7 @@ import six
 from six import iteritems
 from six.moves.urllib.parse import urlencode
 
-from jeti.module_utils.urls import open_url
-
+import requests
 
 class ProxmoxNodeList(list):
     def get_names(self):
@@ -106,7 +105,8 @@ class ProxmoxAPI(object):
             'password': self.options.password,
         })
 
-        data = json.load(open_url(request_path, data=request_params))
+        response = requests.get(request_path, params=request_params)
+        data = response.json
 
         self.credentials = {
             'ticket': data['data']['ticket'],
@@ -117,9 +117,9 @@ class ProxmoxAPI(object):
         request_path = '{0}{1}'.format(self.options.url, url)
 
         headers = {'Cookie': 'PVEAuthCookie={0}'.format(self.credentials['ticket'])}
-        request = open_url(request_path, data=data, headers=headers)
+        request = requests.get(request_path, data=data, headers=headers)
 
-        response = json.load(request)
+        response = request.json
         return response['data']
 
     def nodes(self):


### PR DESCRIPTION
abiquo.py openshift.py and proxmox.py were all using open_url from module utils.

Even with a suitable PYTHONPATH set, unfortunately open_url itself depended on internal libraries from the core of ansible.  While `open_url` made sense as a way of ensuring that a third-party library was not needed on automation targets, jeti inventory will not be used on automation targets, only the controller where jet is run, so this PR switches out open_url for the popular `requests` library which is near ubiquitous in python installations anyway, and easily installed if not present.

This does not fully remove dependency on module_utils, but (with the exception of the ec2.py module utils, which is not present in jeti currently) the remaining functions from module_utils do not depend on having ansible installed.

###Testing.

I am not really able to test any of this, but


abiquo.py appears to generate valid, but empty json.  
I am unable to test openshift.py but it returns after module imports have completed, so is at least fit for some to test.
Although I do not have a proxmox instance, I can see from the stack trace that requests does attempt a connection to a dummy fake url, using a command line like so:

`./proxmox.py --url=http://localhost:1234/ --username=goat --password=rodeo --list`